### PR TITLE
Fix crashes when loading a core dump.

### DIFF
--- a/lib/checks/dependenciescheck.cpp
+++ b/lib/checks/dependenciescheck.cpp
@@ -47,6 +47,8 @@ DependenciesCheck::UnusedDependencies DependenciesCheck::unusedDependencies(ElfF
     for (int i = 0; i < fileSet->size(); ++i) {
         if (i != fileToCheck && fileToCheck >= 0)
             continue;
+        if (fileSet->file(i)->dynamicSection() == nullptr)
+            continue;
         foreach (const auto &needed, fileSet->file(i)->dynamicSection()->neededLibraries()) {
             const auto depIdx = fileIndex.value(needed);
             const auto depFile = fileSet->file(depIdx);

--- a/lib/elf/elffile.cpp
+++ b/lib/elf/elffile.cpp
@@ -206,13 +206,15 @@ void ElfFile::parseSections()
         m_sectionHeaders.push_back(shdr);
     }
 
-    // pass 2: create sections
+    // pass 2: create sections, if any
     // make sure the string table section needed for section names is created first
-    parseSection(m_header->stringTableSectionHeader());
-    for (int i = 0; i < m_header->sectionHeaderCount(); ++i) {
-        if (i == m_header->stringTableSectionHeader())
-            continue;
-        parseSection(i);
+    if (m_header->sectionHeaderCount() > 0) {
+        parseSection(m_header->stringTableSectionHeader());
+        for (int i = 0; i < m_header->sectionHeaderCount(); ++i) {
+            if (i == m_header->stringTableSectionHeader())
+                continue;
+            parseSection(i);
+        }
     }
 
     // pass 3: set section links


### PR DESCRIPTION
The code assumed that the ELF contains some sections, but core dumps don't
have any of them, leading to nullptr dereference and out of bound indexing.